### PR TITLE
Std_turbulece_generator

### DIFF
--- a/numerical_solvers/solvers/SpectralTurbulenceGenerator.py
+++ b/numerical_solvers/solvers/SpectralTurbulenceGenerator.py
@@ -123,8 +123,8 @@ class SpectralTurbulenceGenerator(t.nn.Module):
         - v: 2D array of y-velocity fluctuations (Ny, Nx)
         """
 
-        u_hat = self.std_dev * self.amplitude * t.exp(1j * (self.phase_u + self.omega * time))
-        v_hat = self.std_dev * self.amplitude * t.exp(1j * (self.phase_v + self.omega * time))
+        u_hat = self.amplitude * t.exp(1j * (self.phase_u + self.omega * time))
+        v_hat = self.amplitude * t.exp(1j * (self.phase_v + self.omega * time))
 
 
         if self.is_div_free:

--- a/numerical_solvers/solvers/SpectralTurbulenceGenerator.py
+++ b/numerical_solvers/solvers/SpectralTurbulenceGenerator.py
@@ -5,7 +5,7 @@ class SpectralTurbulenceGenerator(t.nn.Module):
             self,
             domain_size,
             grid_size, 
-            turb_intensity, 
+            std_dev, 
             noise_limiter = (-1E-3,1E-3),
             energy_spectrum=None, 
             frequency_range=None, 
@@ -19,14 +19,14 @@ class SpectralTurbulenceGenerator(t.nn.Module):
         Parameters:
         - domain_size: tuple (Lx, Ly) representing the size of the domain
         - grid_size: tuple (Nx, Ny) representing the number of grid points in each direction
-        - turb_intensity: float, turbulence intensity scaling factor
+        - std_dev: float, turbulence intensity scaling factor - standard deviation scaling factor
         - num_modes: int, number of random Fourier modes to generate (used in RFM method)
         - energy_spectrum: function, energy spectrum function (optional)
         """
         self.Lx, self.Ly = domain_size
         self.Nx, self.Ny = grid_size
         self.desired_std = 1. # desired standard deviation of the output 
-        self.turb_intensity = turb_intensity
+        self.std_dev = std_dev
         self.energy_spectrum = energy_spectrum if energy_spectrum else self.default_energy_spectrum.to(device)
         self.frequency_range = frequency_range if frequency_range else {'k_min': 2.0 * t.pi / min(domain_size), 'k_max': 2.0 * t.pi / (min(domain_size) / 20)}
 
@@ -123,8 +123,8 @@ class SpectralTurbulenceGenerator(t.nn.Module):
         - v: 2D array of y-velocity fluctuations (Ny, Nx)
         """
 
-        u_hat = self.turb_intensity * self.amplitude * t.exp(1j * (self.phase_u + self.omega * time))
-        v_hat = self.turb_intensity * self.amplitude * t.exp(1j * (self.phase_v + self.omega * time))
+        u_hat = self.std_dev * self.amplitude * t.exp(1j * (self.phase_u + self.omega * time))
+        v_hat = self.std_dev * self.amplitude * t.exp(1j * (self.phase_v + self.omega * time))
 
 
         if self.is_div_free:
@@ -150,21 +150,21 @@ class SpectralTurbulenceGenerator(t.nn.Module):
         v = t.real(t.fft.ifft2(v_hat))
 
        
-        if self.turb_intensity < 1E-14:
+        if self.std_dev < 1E-14:
             u,v = 0*self.K, 0*self.K #avoid division by 0 in t.std(u)
         else:
             # u *= (self.desired_std/t.std(u))
             # v *= (self.desired_std/t.std(v))
             
-            # Normalize u and v to have a standard deviation of 1
-            u /= t.std(u)
-            v /= t.std(v)
+            # # Normalize u and v to have a standard deviation of 1
+            # u /= t.std(u)
+            # v /= t.std(v)
             
-            # todo: would the followin chagne the std deviation?
-            u *= self.turb_intensity 
-            v *= self.turb_intensity 
-            # u *= self.turb_intensity / t.std(u)
-            # v *= self.turb_intensity / t.std(v)
+            # # todo: would the followin chagne the std deviation?
+            # u *= self.std_dev 
+            # v *= self.std_dev 
+            u *= self.std_dev / t.std(u)
+            v *= self.std_dev / t.std(v)
             
 
         # Apply limiter

--- a/numerical_solvers/visualization/histogram_turbulence.py
+++ b/numerical_solvers/visualization/histogram_turbulence.py
@@ -143,71 +143,46 @@ def blue_noise_spectrum(k, k_peak = 10000, exponent=1.0):
     """
     return (k / k_peak)**exponent * t.exp(-(k - k_peak)**2 / (2 * (k_peak / 5)**2)) 
 
-def blue_noise_spectrum2(k):
-    return k**(2.0) #t.exp(t.sqrt(k)) 
 
 def gaussian_spectrum(k, k_peak=0, sigma=1):
     return t.exp(-(k - k_peak)**2 / (2 * sigma**2))/(2*t.pi*sigma) 
 
-def generate_blue_noise_spectrum_torch(wavenumbers, beta = 2):
-    # Convert list of wavenumbers to a PyTorch tensor
-    wavenumbers_tensor = t.tensor(wavenumbers)
-    
-    
-    # Apply a linear scaling based on wavenumbers
-    blue_noise_spectrum = (1 + wavenumbers_tensor**beta)
-    
-    return blue_noise_spectrum
-
 def generate_linear_increasing_spectrum(k, alpha =  2.0, c = 1.0):
-    """
-    Generates a spectrum that increases linearly on a log-log plot.
-    
-    Parameters:
-    - u, v: velocity components (not used directly in this simplified function)
-    - grid_dim: grid dimension (not used directly in this simplified function)
-    - alpha: the exponent to create a linearly increasing spectrum on a log-log plot
-
-    Returns:
-    - k: wavenumbers
-    - spectrum: energy spectrum proportional to k^alpha
-    """
-    # Generate wavenumbers from 1 to 500
-    spectrum = c*k**alpha  # E(k) = k^alpha for linear increase in log-log plot
+    spectrum = c*k**alpha
     return spectrum
 
 
-M = 1E4
+M = 1E6
 
 # Initialize the SpectralTurbulenceGenerator (assuming it is already defined somewhere)
 # turbulence_generator = SpectralTurbulenceGenerator(
-#     domain_size, grid_size, turb_intensity=0.0001, noise_limiter=(-1E-3, 1E-3), energy_spectrum = lambda k: t.where(t.isinf(k ** (-5.0 / 3.0)), 0, k ** (-5.0 / 3.0)), frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
+#     domain_size, grid_size, std_dev=0.0001, noise_limiter=(-1E-3, 1E-3), energy_spectrum = lambda k: t.where(t.isinf(k ** (-5.0 / 3.0)), 0, k ** (-5.0 / 3.0)), frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
 # )
 
 turbulence_generator = SpectralTurbulenceGenerator(
-    domain_size, grid_size, turb_intensity=0.01, noise_limiter=(-M, M), energy_spectrum = generate_linear_increasing_spectrum, frequency_range= {'k_min':1E-6, 'k_max': 1E6}
+    domain_size, grid_size, std_dev=0.01, noise_limiter=(-M, M), energy_spectrum = generate_linear_increasing_spectrum, frequency_range= {'k_min': 2.0 * t.pi / min(domain_size), 'k_max': 2.0 * t.pi / (min(domain_size) / 2024)}
 )
 
 # turbulence_generator = SpectralTurbulenceGenerator(
-#     domain_size, grid_size, turb_intensity=0.0001, noise_limiter=(-1E-3, 1E-3), energy_spectrum = gaussian_spectrum, frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
+#     domain_size, grid_size, std_dev=0.0001, noise_limiter=(-1E-3, 1E-3), energy_spectrum = gaussian_spectrum, frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
 # )
 
 
 # turbulence_generator = SpectralTurbulenceGenerator(
-#     domain_size, grid_size, turb_intensity=0.01, noise_limiter=(-M, M), energy_spectrum = blue_noise_spectrum2, frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
+#     domain_size, grid_size, std_dev=0.01, noise_limiter=(-M, M), energy_spectrum = blue_noise_spectrum2, frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
 # )
 
 
 
 
 # turbulence_generator = SpectralTurbulenceGenerator(
-#     domain_size, grid_size, turb_intensity=0.0001, noise_limiter=(-1E-3, 1E-3), energy_spectrum = generate_blue_noise_spectrum_torch, frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
+#     domain_size, grid_size, std_dev=0.0001, noise_limiter=(-1E-3, 1E-3), energy_spectrum = generate_blue_noise_spectrum_torch, frequency_range= {'k_min': 2.0 * np.pi / min(domain_size), 'k_max': 2.0 * np.pi / (min(domain_size) / 1024)}
 # )
 
 
 
 # Generate the turbulent velocity field
-u, v = turbulence_generator.generate_turbulence(time=0.5)
+u, v = turbulence_generator.generate_turbulence(time=2*t.pi)
 # Nx, Ny = grid_size
 # mean=0.0
 # std_dev=1.0
@@ -226,8 +201,8 @@ fig = plt.figure(figsize=(6, 4))
 ax = fig.add_axes([0.2, 0.2, 0.7, 0.7])  # [left, bottom, width, height] as fractions of the figure size
 # Plot the current energy spectrum
 # ax.set_ylim([1E-7, 1E2])
-ax.loglog(k_cpu[1:len(k_cpu)//2 ], 
-          energy_spectrum_cpu[1:len(k_cpu) //2], 
+ax.loglog(k_cpu[1:len(k_cpu)], 
+          energy_spectrum_cpu[1:len(k_cpu)], 
           'b>', label='Energy spectrum')
 
 # Add grid and labels


### PR DESCRIPTION
correct me if I'm wrong: w SpectralTurbulenceGenerator wystarczy zmienić wszędzie nazwę turbulence_intensity na std_deviation i zrobić

u *= std_deviation /t.std(u)
v *= std_deviation /t.std(v)

rozkłady prędkości będą miały odchylenie standardowe równe std_deviation, co odpowiada zamierzonemu efektowi skalowania turbulencji.